### PR TITLE
Feat/disruption pagination

### DIFF
--- a/src/pages/disruption.js
+++ b/src/pages/disruption.js
@@ -276,6 +276,26 @@ const Paginator = props => {
           </Disruption>
         )
       )}
+      <MobileStepper
+        steps={maxSteps}
+        position="static"
+        variant="text"
+        activeStep={activeStep}
+        nextButton={
+          <Button
+            size="small"
+            onClick={handleNext}
+            disabled={activeStep === maxSteps - 1}
+          >
+            <KeyboardArrowRight />
+          </Button>
+        }
+        backButton={
+          <Button size="small" onClick={handleBack} disabled={activeStep === 0}>
+            <KeyboardArrowLeft />
+          </Button>
+        }
+      />
     </>
   )
 }

--- a/src/pages/disruption.js
+++ b/src/pages/disruption.js
@@ -11,16 +11,18 @@ import {
   Link,
   Chip,
   Typography,
-  ExpansionPanel,
-  ExpansionPanelSummary,
-  ExpansionPanelDetails,
+  Card,
+  CardHeader,
+  CardContent,
+  CardActions,
+  IconButton,
+  Collapse,
 } from "@material-ui/core"
 import ExpandMoreIcon from "@material-ui/icons/ExpandMore"
 import SearchIcon from "@material-ui/icons/Search"
 import SEO from "@/components/templates/SEO"
 import Layout from "@components/templates/Layout"
 import { Row } from "@components/atoms/Row"
-
 import { withLanguage } from "../utils/i18n"
 
 const DisruptionSearchBox = styled(TextField)`
@@ -36,7 +38,7 @@ const CategorySelect = styled(Select)`
   margin-bottom: 0.5rem;
 `
 
-const DisruptionExpansionPanel = styled(ExpansionPanel)`
+const DisruptionCard = styled(Card)`
   margin-top: 1rem;
   margin-bottom: 1rem;
 
@@ -46,14 +48,34 @@ const DisruptionExpansionPanel = styled(ExpansionPanel)`
   }
 `
 
-const DisruptionExpansionPanelSummary = styled(ExpansionPanelSummary)`
-  .Mui-expanded {
-    margin: 1rem 0;
-  }
+const DisruptionCardHeader = styled(CardHeader)`
+  padding-bottom: 0px;
+`
+
+const DisruptionCardContent = styled(CardContent)`
+  padding-top: 0.5rem;
+  padding-bottom: 0.5rem;
+`
+
+const DisruptionCardActions = styled(CardActions)`
+  padding-top: 0rem;
+  padding-bottom: 0rem;
+  justify-content: flex-end;
 `
 
 const DisruptionDetail = styled(Typography)`
   color: ${props => props.theme.palette.secondary.main};
+  padding-top: 0.5rem;
+  padding-bottom: 0.5rem;
+`
+
+const DisruptionAction = styled(Box)`
+  padding-left: 0.5rem;
+  flex-grow: 1;
+`
+
+const InvertedExpandMoreIcon = styled(ExpandMoreIcon)`
+  transform: "rotate(180deg)";
 `
 
 const animatedComponents = makeAnimated()
@@ -99,7 +121,8 @@ const DisruptionDescription = props => {
   return (
     <Row>
       <Typography variant="caption">
-        {withLanguage(i18n, node, "description_title")} -{" "}
+        {withLanguage(i18n, node, "description_title")}
+        <br />
         {withLanguage(i18n, node, "description_content")}
       </Typography>
     </Row>
@@ -109,26 +132,23 @@ const DisruptionDescription = props => {
 const Disruption = props => {
   const { node } = props
   const { i18n, t } = useTranslation()
+  const [expanded, setExpanded] = React.useState(false)
+
+  const handleExpandClick = () => {
+    setExpanded(!expanded)
+  }
 
   const sourceUrl = withLanguage(i18n, node, "source_url")
   const hasDescription = props.children && props.children.length > 0
-  const panelSummaryAttributes = hasDescription
-    ? { expandIcon: <ExpandMoreIcon /> }
-    : {}
+  const ExpandIcon = expanded ? InvertedExpandMoreIcon : ExpandMoreIcon
 
   return (
-    <DisruptionExpansionPanel disabled={!hasDescription}>
-      <DisruptionExpansionPanelSummary
-        aria-controls={`panel-${node.id}-content`}
-        id={`panel-${node.id}-header`}
-        {...panelSummaryAttributes}
-      >
+    <DisruptionCard>
+      <DisruptionCardHeader
+        title={withLanguage(i18n, node, "name")}
+      ></DisruptionCardHeader>
+      <DisruptionCardContent>
         <Box alignItems="flex-start">
-          <Row>
-            <Typography variant="h3" component="h2">
-              {withLanguage(i18n, node, "name")}
-            </Typography>
-          </Row>
           <Row>
             <Chip
               label={withLanguage(i18n, node, "category")}
@@ -148,26 +168,43 @@ const Disruption = props => {
           <Row>
             {t("disruption.to")}: {withLanguage(i18n, node, "to") || "-"}
           </Row>
-          {sourceUrl && (
+        </Box>
+      </DisruptionCardContent>
+      <>
+        <DisruptionCardActions disableSpacing>
+          <DisruptionAction>
+            {sourceUrl && (
+              <Row>
+                <Typography variant="caption">
+                  <Link component={Link} href={sourceUrl} target="_blank">
+                    {t("disruption.source")}
+                  </Link>
+                </Typography>
+              </Row>
+            )}
             <Row>
               <Typography variant="caption">
-                <Link component={Link} href={sourceUrl} target="_blank">
-                  {t("disruption.source")}
-                </Link>
+                {t("disruption.last_updated", { date: node.last_update })}
               </Typography>
             </Row>
+          </DisruptionAction>
+          {hasDescription && (
+            <IconButton onClick={handleExpandClick} aria-expanded={expanded}>
+              <ExpandIcon />
+            </IconButton>
           )}
-          <Row>
-            <Typography variant="caption">
-              {t("disruption.last_updated", { date: node.last_update })}
-            </Typography>
-          </Row>
-        </Box>
-      </DisruptionExpansionPanelSummary>
-      <ExpansionPanelDetails>
-        {hasDescription && <Box alignItems="flex-start">{props.children}</Box>}
-      </ExpansionPanelDetails>
-    </DisruptionExpansionPanel>
+        </DisruptionCardActions>
+        {hasDescription && (
+          <Collapse in={expanded} timeout="auto" unmountOnExit>
+            <DisruptionCardContent>
+              {hasDescription && (
+                <Box alignItems="flex-start">{props.children}</Box>
+              )}
+            </DisruptionCardContent>
+          </Collapse>
+        )}
+      </>
+    </DisruptionCard>
   )
 }
 


### PR DESCRIPTION
* **Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines
- [x] i18n translation has been added / updated (for bug fixes / features)


* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ..., provide screenshots if necessary)

  - Take pagination from shop page and apply to disruption page
  - Turn disruption from `ExpansionPanel `to `Card` to make the content clickable
     - "Expand" button is not put at the bottom right hand corner
  - Tune styling and spacing although it still look ugly

* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)


* **Other information**: