### PR TITLE
⛏fix:Use District Filter go to blank page

### DIFF
--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -6,6 +6,7 @@
   "dodgy_shops.source_from": "The information is according to various sources",
   "dodgy_shops.filter_by_district_text": "Search by district",
   "dodgy_shops.filter_text": "Pharmacy Search",
+  "dodgy_shops.no_result": "No results were found",
   "dodgy_shops.report_incident": "Report incident",
   "dodgy_shops.price": "Price",
   "dodgy_shops.level": "Level",

--- a/src/locales/zh/translation.json
+++ b/src/locales/zh/translation.json
@@ -6,6 +6,7 @@
   "dodgy_shops.source_from": "資料來源：炒賣口罩藥房名單",
   "dodgy_shops.filter_by_district_text": "按地區搜尋",
   "dodgy_shops.filter_text": "搜尋藥房",
+  "dodgy_shops.no_result": "沒有符合你要求的藥房",
   "dodgy_shops.report_incident": "報料",
   "dodgy_shops.price": "價錢",
   "dodgy_shops.level": "等級",

--- a/src/pages/shops.js
+++ b/src/pages/shops.js
@@ -3,7 +3,6 @@ import SEO from "@/components/templates/SEO"
 import Layout from "@components/templates/Layout"
 import Box from "@material-ui/core/Box"
 import Link from "@material-ui/core/Link"
-import { UnstyledLinkedCard } from "@components/atoms/LinkedCard"
 import styled from "styled-components"
 import { useTranslation } from "react-i18next"
 import Typography from "@material-ui/core/Typography"
@@ -81,14 +80,7 @@ function item(props, i18n, t) {
   const sourceUrl = node.source_url
 
   return (
-    <UnstyledLinkedCard
-      onClick={() =>
-        window.open(
-          `https://maps.google.com/?q=${withLanguage(i18n, node, "address")}`,
-          "_blank"
-        )
-      }
-    >
+    <>
       <Row>
         <Box>{withLanguage(i18n, node, "type")}</Box>
         <DubiousShopLabel>
@@ -96,7 +88,14 @@ function item(props, i18n, t) {
         </DubiousShopLabel>
       </Row>
       <Row>
-        <Box>{withLanguage(i18n, node, "address")}</Box>
+        <Link 
+          onClick={() =>
+            window.open(`https://maps.google.com/?q=${withLanguage(i18n, node, "address")}`,
+          "_blank")
+          }
+        >
+          {withLanguage(i18n, node, "address")}
+        </Link>
       </Row>
       <Row>
         <Typography variant="h6">{withLanguage(i18n, node, "name")}</Typography>
@@ -132,7 +131,7 @@ function item(props, i18n, t) {
       <Row>
         <Box>{t("dodgy_shops.last_updated", { date: node.last_update })}</Box>
       </Row>
-    </UnstyledLinkedCard>
+    </>
   )
 }
 
@@ -177,6 +176,46 @@ const ShopsPage = props => {
   )
 
   const maxSteps = Math.ceil(filteredData.length / PageSize)
+
+  //Use to reset the activeStep after change filter
+  if(maxSteps > 0 && activeStep >= maxSteps) {
+    setActiveStep(0);
+  }
+
+  const mobileStepper = maxSteps < 2? <div/>: 
+    <MobileStepper
+      steps={maxSteps}
+      position="static"
+      variant="text"
+      activeStep={activeStep}
+      nextButton={
+        <Button
+          size="small"
+          onClick={handleNext}
+          disabled={activeStep === maxSteps - 1}
+        >
+          <KeyboardArrowRight />
+        </Button>
+      }
+      backButton={
+        <Button
+          size="small"
+          onClick={handleBack}
+          disabled={activeStep === 0}
+        >
+          <KeyboardArrowLeft />
+        </Button>
+      }
+    />
+
+  const searchResult = (filteredData.length == 0) ? <Typography variant="h4">{t("dodgy_shops.no_result")}</Typography> :
+    paginate(filteredData, PageSize, activeStep).map((node, index) => (
+      <BasicCard
+        alignItems="flex-start"
+        key={index}
+        children={item(node, i18n, t)}
+      />
+    ));
 
   return (
     <>
@@ -226,62 +265,9 @@ const ShopsPage = props => {
             }}
           />
         </>
-        <MobileStepper
-          steps={maxSteps}
-          position="static"
-          variant="text"
-          activeStep={activeStep}
-          nextButton={
-            <Button
-              size="small"
-              onClick={handleNext}
-              disabled={activeStep === maxSteps - 1}
-            >
-              <KeyboardArrowRight />
-            </Button>
-          }
-          backButton={
-            <Button
-              size="small"
-              onClick={handleBack}
-              disabled={activeStep === 0}
-            >
-              <KeyboardArrowLeft />
-            </Button>
-          }
-        />
-        {paginate(filteredData, PageSize, activeStep).map((node, index) => (
-          <BasicCard
-            alignItems="flex-start"
-            key={index}
-            children={item(node, i18n, t)}
-          />
-        ))}
-        {/* TODO:  Fix button mobile stepper overlapping the bottom nav */}
-        {/* <MobileStepper
-          steps={maxSteps}
-          position="bottom"
-          variant="text"
-          activeStep={activeStep}
-          nextButton={
-            <Button
-              size="small"
-              onClick={handleNext}
-              disabled={activeStep === maxSteps - 1}
-            >
-              <KeyboardArrowRight />
-            </Button>
-          }
-          backButton={
-            <Button
-              size="small"
-              onClick={handleBack}
-              disabled={activeStep === 0}
-            >
-              <KeyboardArrowLeft />
-            </Button>
-          }
-        /> */}
+        {mobileStepper}
+        {searchResult}
+        {mobileStepper}
       </Layout>
     </>
   )

--- a/src/utils/search.js
+++ b/src/utils/search.js
@@ -39,14 +39,18 @@ export const createSubDistrictOptionList = (i18n, edges) => {
 }
 
 export const containsText = (i18n, node, text, fields) => {
-  return fields
-    .map(
-      field =>
-        withLanguage(i18n, node, field)
-          .toLowerCase()
-          .indexOf(text.toLowerCase()) >= 0
-    )
-    .reduce((c, v) => c || v, false)
+  if(typeof text === "string") {
+    return fields
+      .map(
+        field =>
+          withLanguage(i18n, node, field)
+            .toLowerCase()
+            .indexOf(text.toLowerCase()) >= 0
+      )
+      .reduce((c, v) => c || v, false)
+  } else {
+    return false;
+  }
 }
 
 export const searchText = (value, text) =>


### PR DESCRIPTION
Include multiple bugs
⛏fix:Use District Filter go to blank page

<img width="329" alt="Screenshot 2020-02-06 at 12 06 34 AM" src="https://user-images.githubusercontent.com/29300233/73872178-2b750f00-488a-11ea-8487-d1a7baa7632d.png">
⛏fix:Dodgy Shop Display no result for no shop match filter


<img width="331" alt="Screenshot 2020-02-05 at 1 32 47 AM" src="https://user-images.githubusercontent.com/29300233/73872227-434c9300-488a-11ea-98b5-a905b5f0831e.png">
⛏fix:Dodgy Shop clickable area too wide -- change to click on address

⛏fix: paging error in dodgy shop for active page overflow after filter
