### PR TITLE
🔨fix: hide close and dates for small screen

### DIFF
--- a/src/components/organisms/DatePicker.js
+++ b/src/components/organisms/DatePicker.js
@@ -34,6 +34,8 @@ function DatePicker(props) {
   const { focusedInput } = state
   const { t } = useTranslation()
   const isMobile = useMediaQuery(bps.down("md"))
+  const isSmallScreen = useMediaQuery('(max-height:569px)') // iphone SE or smaller
+  const isMidScreen = useMediaQuery('(max-height:732px)') // Pixel 2 or smaller
 
   const phrasesProp = {
     datepickerStartDatePlaceholder: t(
@@ -82,6 +84,8 @@ function DatePicker(props) {
           onFocusChange={focusedInput =>
             dispatch({ type: "focusChange", payload: focusedInput })
           }
+          showSelectedDates={isMidScreen ? false : true}
+          showClose={isSmallScreen ? false : true}
           startDate={startDate}
           endDate={endDate}
           focusedInput={focusedInput}


### PR DESCRIPTION
Iphone SE will not display close and selected dates
<img width="324" alt="Screenshot 2020-02-14 at 2 39 23 AM" src="https://user-images.githubusercontent.com/29300233/74467088-6521c780-4ed3-11ea-8251-a931544f84f8.png">



Pixel 2 will not display close 
<img width="324" alt="Screenshot 2020-02-14 at 2 39 38 AM" src="https://user-images.githubusercontent.com/29300233/74467099-69e67b80-4ed3-11ea-99b3-465a2843bc9d.png">

iphone X desktop or ipad will display all the control button
<img width="324" alt="Screenshot 2020-02-14 at 2 39 48 AM" src="https://user-images.githubusercontent.com/29300233/74467109-6ce16c00-4ed3-11ea-8864-4479794d8fc5.png">


