### PR TITLE
Add a minimum zoom limit

### DIFF
--- a/src/reducers/pageOptions.js
+++ b/src/reducers/pageOptions.js
@@ -4,6 +4,7 @@ export const ALERT_CLOSE = "alert_close"
 export const FONT_ZOOMIN = "font_zoomin"
 export const FONT_ZOOMOUT = "font_zoomout"
 export const FONT_ZOOM_LOCALSTORAGE_KEY = "font_zoom"
+export const FONT_ZOOM_MIN = 0.5
 
 export default (state, action) => {
   switch (action.type) {
@@ -17,8 +18,12 @@ export default (state, action) => {
       return { ...state, fontZoom: state.fontZoom + 0.5 }
     }
     case FONT_ZOOMOUT: {
-      saveToLocalStorage(FONT_ZOOM_LOCALSTORAGE_KEY, state.fontZoom - 0.5)
-      return { ...state, fontZoom: state.fontZoom - 0.5 }
+      const fontZoom = state.fontZoom - 0.5
+      if (fontZoom < FONT_ZOOM_MIN) {
+        return { ...state }
+      }
+      saveToLocalStorage(FONT_ZOOM_LOCALSTORAGE_KEY, fontZoom)
+      return { ...state, fontZoom }
     }
     default:
       return { ...state }


### PR DESCRIPTION
* **Please check if the PR fulfills these requirements**
  - [x] The commit message follows our guidelines
  - [x] i18n translation has been added / updated (for bug fixes / features)


* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ..., provide screenshots if necessary)

  Bugfix: Prevent font_zoom to be anything less than 0.5.

  The current zoom aid would allow visitor to reduce font size all the way to 0. And the zoom icons themselves are affected by the zoom, too. So if you're <strike>stupid</strike> curious like me, you'd got stuck with a page with no visible text and you can't get out of it (unless you know how to remove local storage variable from console).


* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)

  I don't think this change break anything (fingers-crossed)

* **Other information**

  For accessibility, the minimal zoom can actually be 1 instead of 0.5. [WCAG](https://www.w3.org/WAI/standards-guidelines/wcag/) [Success Criterion 1.4.4 Resize text](https://www.w3.org/TR/WCAG21/#resize-text) states that, "Except for captions and images of text, text can be resized without assistive technology up to 200 percent without loss of content or functionality." There is no requirement in reducing font size than the original one.