### PR TITLE
feat: Add progress bar to cases page

### DIFF
--- a/src/pages/cases.js
+++ b/src/pages/cases.js
@@ -3,6 +3,7 @@ import { useTranslation } from "react-i18next"
 import SEO from "@/components/templates/SEO"
 import Layout from "@components/templates/Layout"
 import Typography from "@material-ui/core/Typography"
+import LinearProgress from "@material-ui/core/LinearProgress"
 import { graphql } from "gatsby"
 import { WarsCaseCard } from "@components/organisms/CaseCard"
 import { isSSR } from "@/utils"
@@ -114,6 +115,7 @@ const ConfirmedCasePage = props => {
           onItem={infiniteScrollOnItem}
         />
       </ResponsiveWrapper>
+      <LinearProgress />
     </Layout>
   )
 }


### PR DESCRIPTION
* **Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines


* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ..., provide screenshots if necessary)
Adds a single loading bar to the bottom of the cases page. It still freezes when something is actually loading (as does every other animation and effect), but it should help indicate that the page is actually loading more cases.

* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
no

* **Other information**:
Fixes #183