### PR TITLE
feat/Reduce size of case data (Step 1)

### DIFF
--- a/src/components/molecules/dashboard/LatestCases.js
+++ b/src/components/molecules/dashboard/LatestCases.js
@@ -30,8 +30,6 @@ export default function ConfirmedCaseVisual(props) {
               detail_zh
               detail_en
               classification
-              classification_zh
-              classification_en
               source_url
             }
           }

--- a/src/components/organisms/CaseCard.js
+++ b/src/components/organisms/CaseCard.js
@@ -200,7 +200,7 @@ export const WarsCaseCard = React.forwardRef((props, ref) => {
               }
               size="small"
               fontSize={14}
-              label={withLanguage(i18n, node, "classification")}
+              label={t(`epidemic.${node.classification}`)}
             />
           )}
         </Box>

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -194,8 +194,8 @@
   "epidemic.imported": "Imported",
   "epidemic.imported_close_contact": "Close contact of imported case",
   "epidemic.local": "Local",
-  "epidemic.local_close_contact": "Close contact of local case",
+  "epidemic.local_close_contact": "Close contact with local case",
   "epidemic.local_possibly": "Possibly local",
-  "epidemic.local_possibly_close_contact": "Close contact of possibly local case",
+  "epidemic.local_possibly_close_contact": "Close contact with suspected local case",
   "epidemic.remarks": "Asymptomatic cases are not shown in this epidemic curve, source: CHP"
 }

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -196,6 +196,6 @@
   "epidemic.local": "Local",
   "epidemic.local_close_contact": "Close contact with local case",
   "epidemic.local_possibly": "Possibly local",
-  "epidemic.local_possibly_close_contact": "Close contact with suspected local case",
+  "epidemic.local_possibly_close_contact": "Close contact of possibly local case",
   "epidemic.remarks": "Asymptomatic cases are not shown in this epidemic curve, source: CHP"
 }

--- a/src/pages/cases.js
+++ b/src/pages/cases.js
@@ -138,8 +138,6 @@ export const ConfirmedCaseQuery = graphql`
           hospital_zh
           hospital_en
           status
-          status_zh
-          status_en
           type_zh
           type_en
           citizenship_zh
@@ -147,8 +145,6 @@ export const ConfirmedCaseQuery = graphql`
           detail_zh
           detail_en
           classification
-          classification_zh
-          classification_en
           source_url
         }
       }


### PR DESCRIPTION
* **Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines
- [x] i18n translation has been added / updated (for bug fixes / features)


* **What kind of change does this PR introduce?**
Reduces size of case data (slightly) by removing the need for status_en and status_zh columns; they have not been erased from the database, but they will not be sent to every user anymore.
Targeted at #185

* **Does this PR introduce a breaking change?**
The end goal is to remove all _en and _zh columns from the case database; this has not been done yet, but minor changes in the application will be expected to accomplish this.
