### PR TITLE
Pre map revamp data unify

### DIFF
--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -730,15 +730,23 @@ exports.createPages = async ({ graphql, actions }) => {
   })
   return Promise.resolve(null)
 }
-
-exports.onPostBuild = ({ reporter }) => {
+exports.onPostBuild = async ({ graphql, reporter }) => {
   reporter.info("Injecting cases pages sitemap record")
   const fs = require("fs")
-  const casesData = require("./public/page-data/cases/page-data.json")
+  const result = await graphql(`
+  query {
+    allWarsCase {
+      edges {
+        node {
+          case_no
+        }
+      }
+    }
+  }`)
   const template = no =>
     `<url> <loc>https://wars.vote4.hk/cases/${no}</loc> <changefreq>daily</changefreq> <priority>0.7</priority> </url>
 <url> <loc>https://wars.vote4.hk/en/cases/${no}</loc> <changefreq>daily</changefreq> <priority>0.7</priority> </url>`
-  const caseNos = casesData.result.data.allWarsCase.edges.map(
+  const caseNos = result.data.allWarsCase.edges.map(
     i => i.node.case_no
   )
   const sitemapXml = fs.readFileSync("./public/sitemap.xml", "utf-8")

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
   ],
   "dependencies": {
     "@datepicker-react/styled": "^2.3.1",
-    "@material-ui/core": "^4.8.3",
+    "@material-ui/core": "^4.11.1",
     "@material-ui/icons": "^4.5.1",
     "@material-ui/lab": "^4.0.0-alpha.40",
     "c3": "^0.7.12",

--- a/src/components/data/useAllCasesData.js
+++ b/src/components/data/useAllCasesData.js
@@ -1,0 +1,77 @@
+import { graphql, useStaticQuery } from "gatsby"
+export const useAllCasesData = () =>
+  useStaticQuery(graphql`
+    query {
+      allWarsCase {
+        edges {
+          node {
+            case_no
+            onset_date
+            confirmation_date
+            gender
+            age
+            hospital_zh
+            hospital_en
+            status
+            status_zh
+            status_en
+            type_zh
+            type_en
+            citizenship_zh
+            citizenship_en
+            citizenship_district_zh
+            citizenship_district_en
+            detail_zh
+            detail_en
+            classification
+            classification_zh
+            classification_en
+            source_url_1
+            source_url_2
+            source_url_3
+            source_url_4
+            source_url_5
+          }
+        }
+      }
+      allWarsCaseRelation {
+        edges {
+          node {
+            case_no
+            name_zh
+            name_en
+            description_zh
+            description_en
+          }
+        }
+      }
+      patient_track: allWarsCaseLocation(
+        sort: { order: DESC, fields: end_date }
+      ) {
+        group(field: case___case_no) {
+          fieldValue
+          edges {
+            node {
+              id
+              action_en
+              action_zh
+              case_no
+              end_date
+              lat
+              lng
+              location_en
+              location_zh
+              remarks_en
+              remarks_zh
+              source_url_1
+              source_url_2
+              start_date
+              sub_district_en
+              sub_district_zh
+              type
+            }
+          }
+        }
+      }
+    }
+  `)

--- a/src/pages/cases.js
+++ b/src/pages/cases.js
@@ -382,7 +382,7 @@ const CasesPage = props => {
       patientTrack={
         patientTrackKeyedByCaseNo[node.case_no]
           ? [patientTrackKeyedByCaseNo[node.case_no]]
-          : []
+          : null
       }
       handleClose={
         view === CASES_BOX_VIEW ? e => setSelectedCase(null) : undefined

--- a/src/pages/cases.js
+++ b/src/pages/cases.js
@@ -9,7 +9,7 @@ import MenuItem from "@material-ui/core/MenuItem"
 import { bps } from "@/ui/theme"
 import SEO from "@/components/templates/SEO"
 import Layout from "@components/templates/Layout"
-import { graphql } from "gatsby"
+import {useAllCasesData} from "@components/data/useAllCasesData"
 import TagStyleFilter from "@/components/molecules/TagStyleFilter"
 import { createDedupOptions } from "@/utils/search"
 import { mapColorForStatus } from "@/utils/colorHelper"
@@ -128,7 +128,7 @@ const Circle = styled.div`
 `
 
 const CasesPage = props => {
-  const { data } = props
+  const data = useAllCasesData();
   const {
     cases: {
       dispatch,
@@ -676,77 +676,3 @@ const CasesPage = props => {
 }
 
 export default CasesPage
-
-export const CasesPageQuery = graphql`
-  query {
-    allWarsCase {
-      edges {
-        node {
-          case_no
-          onset_date
-          confirmation_date
-          gender
-          age
-          hospital_zh
-          hospital_en
-          status
-          status_zh
-          status_en
-          type_zh
-          type_en
-          citizenship_zh
-          citizenship_en
-          citizenship_district_zh
-          citizenship_district_en
-          detail_zh
-          detail_en
-          classification
-          classification_zh
-          classification_en
-          source_url_1
-          source_url_2
-          source_url_3
-          source_url_4
-          source_url_5
-        }
-      }
-    }
-    allWarsCaseRelation {
-      edges {
-        node {
-          case_no
-          name_zh
-          name_en
-          description_zh
-          description_en
-        }
-      }
-    }
-    patient_track: allWarsCaseLocation(
-      sort: { order: DESC, fields: end_date }
-    ) {
-      group(field: case___case_no) {
-        fieldValue
-        edges {
-          node {
-            action_en
-            action_zh
-            case_no
-            end_date
-            lat
-            lng
-            location_en
-            location_zh
-            remarks_en
-            remarks_zh
-            source_url_1
-            source_url_2
-            start_date
-            sub_district_en
-            sub_district_zh
-          }
-        }
-      }
-    }
-  }
-`

--- a/src/pages/cases.js
+++ b/src/pages/cases.js
@@ -2,6 +2,7 @@ import React, { useState, useMemo } from "react"
 import { useTranslation } from "react-i18next"
 import styled from "styled-components"
 import _groupBy from "lodash/groupBy"
+import _keyBy from "lodash/keyBy"
 import Typography from "@material-ui/core/Typography"
 import MenuItem from "@material-ui/core/MenuItem"
 
@@ -366,7 +367,10 @@ const CasesPage = props => {
   if (isNaN(preloadedCases)) {
     preloadedCases = 15
   }
-
+  const patientTrackKeyedByCaseNo = useMemo(
+    () => _keyBy(data.patient_track.group, "fieldValue"),
+    [data]
+  )
   const renderCaseCard = node => (
     <WarsCaseCard
       node={node}
@@ -375,9 +379,11 @@ const CasesPage = props => {
       key={node.case_no}
       // isSelected={selectedCase === item.node.case_no}
       // ref={selectedCase === item.node.case_no ? selectedCard : null}
-      patientTrack={data.patient_track.group.filter(
-        t => t.fieldValue === node.case_no
-      )}
+      patientTrack={
+        patientTrackKeyedByCaseNo[node.case_no]
+          ? [patientTrackKeyedByCaseNo[node.case_no]]
+          : []
+      }
       handleClose={
         view === CASES_BOX_VIEW ? e => setSelectedCase(null) : undefined
       }
@@ -723,19 +729,21 @@ export const CasesPageQuery = graphql`
         fieldValue
         edges {
           node {
-            case_no
-            start_date
-            end_date
-            sub_district_zh
-            sub_district_en
-            location_zh
-            location_en
-            action_zh
             action_en
-            remarks_zh
+            action_zh
+            case_no
+            end_date
+            lat
+            lng
+            location_en
+            location_zh
             remarks_en
+            remarks_zh
             source_url_1
             source_url_2
+            start_date
+            sub_district_en
+            sub_district_zh
           }
         }
       }

--- a/src/pages/high-risk.js
+++ b/src/pages/high-risk.js
@@ -1,9 +1,8 @@
-import React, { useState, useRef, useEffect } from "react"
+import React, { useState, useRef, useEffect, useMemo } from "react"
 import SEO from "@/components/templates/SEO"
 import Layout from "@components/templates/Layout"
 import { useTranslation } from "react-i18next"
 import { Box, Typography, Tooltip, ClickAwayListener } from "@material-ui/core"
-import { graphql } from "gatsby"
 import styled from "styled-components"
 import MuiLink from "@material-ui/core/Link"
 import { Link } from "gatsby"
@@ -14,6 +13,8 @@ import { makeStyles } from "@material-ui/core/styles"
 import AutoSizer from "react-virtualized/dist/es/AutoSizer"
 import * as d3 from "d3"
 import _groupBy from "lodash/groupBy"
+import _flatMap from "lodash/flatMap"
+import _orderBy from "lodash/orderBy"
 import DatePicker from "@/components/organisms/DatePicker"
 import Theme from "@/ui/theme"
 import { trackCustomEvent } from "gatsby-plugin-google-analytics"
@@ -25,6 +26,7 @@ import {
 import MultiPurposeSearch from "../components/molecules/MultiPurposeSearch"
 import { grey } from "@material-ui/core/colors"
 import { formatDateMDD, isSSR } from "@/utils"
+import { useAllCasesData } from "@components/data/useAllCasesData"
 
 const HighRiskMap = React.lazy(() =>
   import(/* webpackPrefetch: true */ "@components/highRiskMap")
@@ -239,7 +241,15 @@ const useStyle = makeStyles(theme => {
   }
 })
 
-const HighRiskPage = ({ data }) => {
+const HighRiskPage = () => {
+  const allCasesPageData = useAllCasesData()
+  const data = useMemo(() => {
+    const edges = _orderBy(
+      _flatMap(allCasesPageData.patient_track.group, "edges"),
+      "node.end_date"
+    ).filter(i => i.node.action_zh !== "求醫")
+    return { allWarsCaseLocation: { edges } }
+  }, [allCasesPageData])
   const [searchStartDate, setSearchStartDate] = useState(null)
   const [searchEndDate, setSearchEndDate] = useState(null)
   const { i18n, t } = useTranslation()
@@ -410,37 +420,3 @@ const HighRiskPage = ({ data }) => {
 }
 
 export default HighRiskPage
-
-export const HighRiskQuery = graphql`
-  query {
-    allWarsCaseLocation(
-      sort: { order: DESC, fields: end_date }
-      filter: { action_zh: { ne: "求醫" } }
-    ) {
-      edges {
-        node {
-          id
-          action_en
-          action_zh
-          case_no
-          end_date
-          lat
-          lng
-          location_en
-          location_zh
-          remarks_en
-          remarks_zh
-          source_url_1
-          source_url_2
-          start_date
-          sub_district_en
-          sub_district_zh
-          type
-          case {
-            case_no
-          }
-        }
-      }
-    }
-  }
-`

--- a/src/pages/high-risk.js
+++ b/src/pages/high-risk.js
@@ -420,10 +420,12 @@ export const HighRiskQuery = graphql`
       edges {
         node {
           id
-          sub_district_zh
-          sub_district_en
-          action_zh
           action_en
+          action_zh
+          case_no
+          end_date
+          lat
+          lng
           location_en
           location_zh
           remarks_en
@@ -431,11 +433,9 @@ export const HighRiskQuery = graphql`
           source_url_1
           source_url_2
           start_date
-          end_date
-          lat
-          lng
+          sub_district_en
+          sub_district_zh
           type
-          case_no
           case {
             case_no
           }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1975,10 +1975,15 @@
     "@emotion/utils" "0.11.3"
     babel-plugin-emotion "^10.0.27"
 
-"@emotion/hash@0.7.4", "@emotion/hash@^0.7.4":
+"@emotion/hash@0.7.4":
   version "0.7.4"
   resolved "https://registry.yarnpkg.com/@emotion/hash/-/hash-0.7.4.tgz#f14932887422c9056b15a8d222a9074a7dfa2831"
   integrity sha512-fxfMSBMX3tlIbKUdtGKxqB1fyrH6gVrX39Gsv3y8lRYKUqlgDt3UMqQyGnR1bQMa2B8aGnhLZokZgg8vT0Le+A==
+
+"@emotion/hash@^0.8.0":
+  version "0.8.0"
+  resolved "https://registry.yarnpkg.com/@emotion/hash/-/hash-0.8.0.tgz#bbbff68978fefdbe68ccb533bc8cbe1d1afb5413"
+  integrity sha512-kBJtf7PH6aWwZ6fka3zQ0p6SBYzx4fl1LoZXE2RrnYST9Xljm7WfKJrU4g/Xr3Beg72MLrp1AWNUmuYJTL7Cow==
 
 "@emotion/is-prop-valid@0.8.6", "@emotion/is-prop-valid@^0.8.3":
   version "0.8.6"
@@ -2535,25 +2540,23 @@
   dependencies:
     core-js "^2.5.7"
 
-"@material-ui/core@^4.8.3":
-  version "4.9.0"
-  resolved "https://registry.yarnpkg.com/@material-ui/core/-/core-4.9.0.tgz#96ca3281ee06216d44fd4d0e306dbe0429eb2ebe"
-  integrity sha512-zrrr8mPU5DDBYaVil4uJYauW41PjSn5otn7cqGsmWOY0t90fypr9nNgM7rRJaPz2AP6oRSDx1kBQt2igf5uelg==
+"@material-ui/core@^4.11.1":
+  version "4.11.2"
+  resolved "https://registry.yarnpkg.com/@material-ui/core/-/core-4.11.2.tgz#f8276dfa40d88304e6ceb98962af73803d27d42d"
+  integrity sha512-/D1+AQQeYX/WhT/FUk78UCRj8ch/RCglsQLYujYTIqPSJlwZHKcvHidNeVhODXeApojeXjkl0tWdk5C9ofwOkQ==
   dependencies:
     "@babel/runtime" "^7.4.4"
-    "@material-ui/styles" "^4.9.0"
-    "@material-ui/system" "^4.7.1"
-    "@material-ui/types" "^5.0.0"
-    "@material-ui/utils" "^4.7.1"
+    "@material-ui/styles" "^4.11.2"
+    "@material-ui/system" "^4.11.2"
+    "@material-ui/types" "^5.1.0"
+    "@material-ui/utils" "^4.11.2"
     "@types/react-transition-group" "^4.2.0"
-    clsx "^1.0.2"
-    convert-css-length "^2.0.1"
-    hoist-non-react-statics "^3.2.1"
-    normalize-scroll-left "^0.2.0"
-    popper.js "^1.14.1"
+    clsx "^1.0.4"
+    hoist-non-react-statics "^3.3.2"
+    popper.js "1.16.1-lts"
     prop-types "^15.7.2"
-    react-is "^16.8.0"
-    react-transition-group "^4.3.0"
+    react-is "^16.8.0 || ^17.0.0"
+    react-transition-group "^4.4.0"
 
 "@material-ui/icons@^4.5.1":
   version "4.5.1"
@@ -2573,18 +2576,18 @@
     prop-types "^15.7.2"
     react-is "^16.8.0"
 
-"@material-ui/styles@^4.9.0":
-  version "4.9.0"
-  resolved "https://registry.yarnpkg.com/@material-ui/styles/-/styles-4.9.0.tgz#10c31859f6868cfa9d3adf6b6c3e32c9d676bc76"
-  integrity sha512-nJHum4RqYBPWsjL/9JET8Z02FZ9gSizlg/7LWVFpIthNzpK6OQ5OSRR4T4x9/p+wK3t1qNn3b1uI4XpnZaPxOA==
+"@material-ui/styles@^4.11.2":
+  version "4.11.2"
+  resolved "https://registry.yarnpkg.com/@material-ui/styles/-/styles-4.11.2.tgz#e70558be3f41719e8c0d63c7a3c9ae163fdc84cb"
+  integrity sha512-xbItf8zkfD3FuGoD9f2vlcyPf9jTEtj9YTJoNNV+NMWaSAHXgrW6geqRoo/IwBuMjqpwqsZhct13e2nUyU9Ljw==
   dependencies:
     "@babel/runtime" "^7.4.4"
-    "@emotion/hash" "^0.7.4"
-    "@material-ui/types" "^5.0.0"
-    "@material-ui/utils" "^4.7.1"
-    clsx "^1.0.2"
+    "@emotion/hash" "^0.8.0"
+    "@material-ui/types" "^5.1.0"
+    "@material-ui/utils" "^4.11.2"
+    clsx "^1.0.4"
     csstype "^2.5.2"
-    hoist-non-react-statics "^3.2.1"
+    hoist-non-react-statics "^3.3.2"
     jss "^10.0.3"
     jss-plugin-camel-case "^10.0.3"
     jss-plugin-default-unit "^10.0.3"
@@ -2595,19 +2598,29 @@
     jss-plugin-vendor-prefixer "^10.0.3"
     prop-types "^15.7.2"
 
-"@material-ui/system@^4.7.1":
-  version "4.7.1"
-  resolved "https://registry.yarnpkg.com/@material-ui/system/-/system-4.7.1.tgz#d928dacc0eeae6bea569ff3ee079f409efb3517d"
-  integrity sha512-zH02p+FOimXLSKOW/OT2laYkl9bB3dD1AvnZqsHYoseUaq0aVrpbl2BGjQi+vJ5lg8w73uYlt9zOWzb3+1UdMQ==
+"@material-ui/system@^4.11.2":
+  version "4.11.2"
+  resolved "https://registry.yarnpkg.com/@material-ui/system/-/system-4.11.2.tgz#7f0a754bba3673ed5fdbfa02fe438096c104b1f6"
+  integrity sha512-BELFJEel5E+5DMiZb6XXT3peWRn6UixRvBtKwSxqntmD0+zwbbfCij6jtGwwdJhN1qX/aXrKu10zX31GBaeR7A==
   dependencies:
     "@babel/runtime" "^7.4.4"
-    "@material-ui/utils" "^4.7.1"
+    "@material-ui/utils" "^4.11.2"
+    csstype "^2.5.2"
     prop-types "^15.7.2"
 
-"@material-ui/types@^5.0.0":
-  version "5.0.0"
-  resolved "https://registry.yarnpkg.com/@material-ui/types/-/types-5.0.0.tgz#26d6259dc6b39f4c2e1e9aceff7a11e031941741"
-  integrity sha512-UeH2BuKkwDndtMSS0qgx1kCzSMw+ydtj0xx/XbFtxNSTlXydKwzs5gVW5ZKsFlAkwoOOQ9TIsyoCC8hq18tOwg==
+"@material-ui/types@^5.1.0":
+  version "5.1.0"
+  resolved "https://registry.yarnpkg.com/@material-ui/types/-/types-5.1.0.tgz#efa1c7a0b0eaa4c7c87ac0390445f0f88b0d88f2"
+  integrity sha512-7cqRjrY50b8QzRSYyhSpx4WRw2YuO0KKIGQEVk5J8uoz2BanawykgZGoWEqKm7pVIbzFDN0SpPcVV4IhOFkl8A==
+
+"@material-ui/utils@^4.11.2":
+  version "4.11.2"
+  resolved "https://registry.yarnpkg.com/@material-ui/utils/-/utils-4.11.2.tgz#f1aefa7e7dff2ebcb97d31de51aecab1bb57540a"
+  integrity sha512-Uul8w38u+PICe2Fg2pDKCaIG7kOyhowZ9vjiC1FsVwPABTW8vPPKfF6OvxRq3IiBaI1faOJmgdvMG7rMJARBhA==
+  dependencies:
+    "@babel/runtime" "^7.4.4"
+    prop-types "^15.7.2"
+    react-is "^16.8.0 || ^17.0.0"
 
 "@material-ui/utils@^4.7.1":
   version "4.7.1"
@@ -6626,7 +6639,7 @@ clsx@^1.0.1:
   resolved "https://registry.yarnpkg.com/clsx/-/clsx-1.1.0.tgz#62937c6adfea771247c34b54d320fb99624f5702"
   integrity sha512-3avwM37fSK5oP6M5rQ9CNe99lwxhXDOeSWVPAOYF6OazUTgZCMb0yWlJpmdD74REy1gkEaFiub2ULv4fq9GUhA==
 
-clsx@^1.0.2, clsx@^1.0.4:
+clsx@^1.0.4:
   version "1.0.4"
   resolved "https://registry.yarnpkg.com/clsx/-/clsx-1.0.4.tgz#0c0171f6d5cb2fe83848463c15fcc26b4df8c2ec"
   integrity sha512-1mQ557MIZTrL/140j+JVdRM6e31/OA4vTYxXgqIIZlndyfjHpyawKZia1Im05Vp9BWmImkcNrNtFYQMyFcgJDg==
@@ -6924,11 +6937,6 @@ contentful-sdk-core@^6.4.0:
   dependencies:
     fast-copy "^2.1.0"
     qs "^6.9.4"
-
-convert-css-length@^2.0.1:
-  version "2.0.1"
-  resolved "https://registry.yarnpkg.com/convert-css-length/-/convert-css-length-2.0.1.tgz#90a76bde5bfd24d72881a5b45d02249b2c1d257c"
-  integrity sha512-iGpbcvhLPRKUbBc0Quxx7w/bV14AC3ItuBEGMahA5WTYqB8lq9jH0kTXFheCBASsYnqeMFZhiTruNxr1N59Axg==
 
 convert-hrtime@^3.0.0:
   version "3.0.0"
@@ -11460,7 +11468,7 @@ hmac-drbg@^1.0.0:
     minimalistic-assert "^1.0.0"
     minimalistic-crypto-utils "^1.0.1"
 
-hoist-non-react-statics@^3.0.0, hoist-non-react-statics@^3.2.1, hoist-non-react-statics@^3.3.0:
+hoist-non-react-statics@^3.0.0, hoist-non-react-statics@^3.3.0, hoist-non-react-statics@^3.3.2:
   version "3.3.2"
   resolved "https://registry.yarnpkg.com/hoist-non-react-statics/-/hoist-non-react-statics-3.3.2.tgz#ece0acaf71d62c2969c2ec59feff42a4b1a85b45"
   integrity sha512-/gGivxi8JPKWNm/W0jSmzcMPpfpPLc3dY/6GxhX2hQ9iGj3aDfklV4ET7NjKpSinLpJ5vafa9iiGIEZg10SfBw==
@@ -14926,11 +14934,6 @@ normalize-range@^0.1.2:
   resolved "https://registry.yarnpkg.com/normalize-range/-/normalize-range-0.1.2.tgz#2d10c06bdfd312ea9777695a4d28439456b75942"
   integrity sha1-LRDAa9/TEuqXd2laTShDlFa3WUI=
 
-normalize-scroll-left@^0.2.0:
-  version "0.2.0"
-  resolved "https://registry.yarnpkg.com/normalize-scroll-left/-/normalize-scroll-left-0.2.0.tgz#9445d74275f303cc661e113329aefa492f58114c"
-  integrity sha512-t5oCENZJl8TGusJKoCJm7+asaSsPuNmK6+iEjrZ5TyBj2f02brCRsd4c83hwtu+e5d4LCSBZ0uoDlMjBo+A8yA==
-
 normalize-url@1.9.1:
   version "1.9.1"
   resolved "https://registry.yarnpkg.com/normalize-url/-/normalize-url-1.9.1.tgz#2cc0d66b31ea23036458436e3620d85954c66c3c"
@@ -16146,7 +16149,12 @@ polished@^3.3.1:
   dependencies:
     "@babel/runtime" "^7.6.3"
 
-popper.js@^1.14.1, popper.js@^1.14.4, popper.js@^1.14.7:
+popper.js@1.16.1-lts:
+  version "1.16.1-lts"
+  resolved "https://registry.yarnpkg.com/popper.js/-/popper.js-1.16.1-lts.tgz#cf6847b807da3799d80ee3d6d2f90df8a3f50b05"
+  integrity sha512-Kjw8nKRl1m+VrSFCoVGPph93W/qrSO7ZkqPpTf7F4bk/sqcfWK019dWBUpE/fBOsOQY1dks/Bmcbfn1heM/IsA==
+
+popper.js@^1.14.4, popper.js@^1.14.7:
   version "1.16.1"
   resolved "https://registry.yarnpkg.com/popper.js/-/popper.js-1.16.1.tgz#2a223cb3dc7b6213d740e40372be40de43e65b1b"
   integrity sha512-Wb4p1J4zyFTbM+u6WuO4XstYx4Ky9Cewe4DWrel7B0w6VVICvPwdOpotjzcf6eD8TsckVnIMNONQyPIUFOUbCQ==
@@ -17264,6 +17272,11 @@ react-is@^16.8.0, react-is@^16.8.4:
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-16.12.0.tgz#2cc0fe0fba742d97fd527c42a13bec4eeb06241c"
   integrity sha512-rPCkf/mWBtKc97aLL9/txD8DZdemK0vkA3JMLShjlJB3Pj3s+lpf1KaBzMfQrAmhMQB0n1cU/SUGgKKBCe837Q==
 
+"react-is@^16.8.0 || ^17.0.0":
+  version "17.0.1"
+  resolved "https://registry.yarnpkg.com/react-is/-/react-is-17.0.1.tgz#5b3531bd76a645a4c9fb6e693ed36419e3301339"
+  integrity sha512-NAnt2iGDXohE5LI7uBnLnqvLQMtzhkiAOLXTmv+qnF9Ky7xAPcX8Up/xWIhxvLVGJvuLiNc4xQLtuqDRzb4fSA==
+
 react-lifecycles-compat@^3.0.4:
   version "3.0.4"
   resolved "https://registry.yarnpkg.com/react-lifecycles-compat/-/react-lifecycles-compat-3.0.4.tgz#4f1a273afdfc8f3488a8c516bfda78f872352362"
@@ -17374,10 +17387,10 @@ react-transition-group@^2.2.1:
     prop-types "^15.6.2"
     react-lifecycles-compat "^3.0.4"
 
-react-transition-group@^4.3.0:
-  version "4.3.0"
-  resolved "https://registry.yarnpkg.com/react-transition-group/-/react-transition-group-4.3.0.tgz#fea832e386cf8796c58b61874a3319704f5ce683"
-  integrity sha512-1qRV1ZuVSdxPlPf4O8t7inxUGpdyO5zG9IoNfJxSO0ImU2A1YWkEQvFPuIPZmMLkg5hYs7vv5mMOyfgSkvAwvw==
+react-transition-group@^4.4.0:
+  version "4.4.1"
+  resolved "https://registry.yarnpkg.com/react-transition-group/-/react-transition-group-4.4.1.tgz#63868f9325a38ea5ee9535d828327f85773345c9"
+  integrity sha512-Djqr7OQ2aPUiYurhPalTrVy9ddmFCCzwhqQmtN+J3+3DzLO209Fdr70QrN8Z3DsglWql6iY1lDWAfpFiBtuKGw==
   dependencies:
     "@babel/runtime" "^7.5.5"
     dom-helpers "^5.0.1"


### PR DESCRIPTION
- unify data source for cases and 'high-risk' (shall reduce size of build output from 76MB -> 40.4MB) by removing need of repeating data.
- upgrade Material-UI for better cases page performance
